### PR TITLE
fix mod doesn't work when it's server-only

### DIFF
--- a/src/main/java/net/mitask/riptidefix/mixin/TridentFixMixin.java
+++ b/src/main/java/net/mitask/riptidefix/mixin/TridentFixMixin.java
@@ -2,43 +2,31 @@ package net.mitask.riptidefix.mixin;
 
 import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
 import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
-import net.minecraft.world.effect.MobEffects;
+import net.minecraft.core.Holder;
+import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.entity.ai.attributes.Attribute;
 import net.minecraft.world.entity.ai.attributes.Attributes;
-import net.minecraft.world.level.material.FluidState;
 import net.minecraft.world.phys.Vec3;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Mixin(LivingEntity.class)
 public abstract class TridentFixMixin {
     @Shadow protected int autoSpinAttackTicks;
-    @Shadow public abstract boolean isAffectedByFluids();
-    @Shadow protected abstract float getWaterSlowDown();
 
-    @WrapOperation(method = "travelInWater", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/phys/Vec3;multiply(DDD)Lnet/minecraft/world/phys/Vec3;"))
-    private Vec3 riptideFix_travelInWater(Vec3 instance, double x, double y, double z, Operation<Vec3> original) {
-        LivingEntity entity = LivingEntity.class.cast(this);
-        FluidState fluidState = entity.level().getFluidState(entity.blockPosition());
-        if (!entity.isInWater() || !isAffectedByFluids() || entity.canStandOnFluid(fluidState)) return instance.multiply(x, y, z);
+    @WrapOperation(method = "travelInWater", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/entity/LivingEntity;getAttributeValue(Lnet/minecraft/core/Holder;)D"))
+    private double riptideFix$ignoreDepthStriderDuringRiptide(LivingEntity instance, Holder<Attribute> attribute, Operation<Double> original) {
+        return autoSpinAttackTicks > 0 && attribute == Attributes.WATER_MOVEMENT_EFFICIENCY ? 0.0 : original.call(instance, attribute);
+    }
 
-        float f = entity.isSprinting() ? 0.9F : getWaterSlowDown();
-        float h = (float)entity.getAttributeValue(Attributes.WATER_MOVEMENT_EFFICIENCY);
-        if (!entity.onGround()) {
-            h *= 0.5F;
+    @Inject(method = "travelInWater", at = @At("TAIL"))
+    private void riptideFix$syncRiptideVelocityToClient(Vec3 input, double baseGravity, boolean isFalling, double oldY, CallbackInfo ci) {
+        if (autoSpinAttackTicks == 20 && (LivingEntity)(Object)this instanceof ServerPlayer player && player.getAttributeValue(Attributes.WATER_MOVEMENT_EFFICIENCY) > 0.0) {
+            player.hurtMarked = true;
         }
-
-        if (h > 0.0f) {
-            if (autoSpinAttackTicks == 0) {
-                f += (0.54600006F - f) * h;
-            }
-        }
-
-        if (entity.hasEffect(MobEffects.DOLPHINS_GRACE)) {
-            f = 0.96F;
-        }
-
-        return instance.multiply(f, y, f);
     }
 }

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -19,6 +19,6 @@
   ],
   "depends": {
     "fabricloader": ">=${loader_version}",
-    "minecraft": ">=26.1"
+    "minecraft": ">=${minecraft_version}"
   }
 }


### PR DESCRIPTION
Fixes riptide movement not working correctly when the mod is installed only server-side.

The old implementation changed the final water slowdown value, but this happened after client already applied water movement efficiency earlier in the same movement calculation. Because of that, part of the wrong riptide behavior could still happen before the fix.


New implementation is treating water movement efficiency as `0.0` while the player is riptiding. This makes vanilla to skip the water movement efficiency adjustment during riptide while still letting vanilla handle the rest of the movement values normally including dolphin effect etc ^^

If player has high ping, it may feel a bit laggy/buggy because currently server needs to sync the corrected riptide velocity back to the client. Since client still predict the old movement locally, the server has to send an update so the client follows the fixed server-side velocity